### PR TITLE
Fix UE5.4 compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ local.sqlite
 local.db
 **/generated
 **/*.generated
+
+# Unreal Engine
+Intermediate/
+Binaries/

--- a/Source/BeamSDK/External/Random.h
+++ b/Source/BeamSDK/External/Random.h
@@ -82,8 +82,9 @@ static int fill_random(unsigned char data[], size_t size) {
     } else {
         return 0;
     }
-#endif
+#else
     return 0;
+#endif
 }
 
 /*static void print_hex(unsigned char* data, size_t size) {


### PR DESCRIPTION
It is unclear why 5.4 broke on that line when all other UE versions we tested worked.
In the interest of process efficiency, also sideloaded .gitignore changes into this PR that were removed in a prior commit.